### PR TITLE
Add more languages for the Explore shortcut and add Polish translation

### DIFF
--- a/Launcher/App/src/main/java/com/lvonasek/pilauncher/ButtonManager.java
+++ b/Launcher/App/src/main/java/com/lvonasek/pilauncher/ButtonManager.java
@@ -10,8 +10,10 @@ public class ButtonManager extends AccessibilityService
     public void onAccessibilityEvent(AccessibilityEvent event)
     {
         if (event.getEventType() == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-            if ("[Explore]".compareTo(event.getText().toString()) == 0 ||
-                    "[Explorer]".compareTo(event.getText().toString()) == 0) {
+            String eventText = event.getText().toString();
+            String exploreAccessibilityEventName = getResources().getString(R.string.explore_accessibility_event_name);
+
+            if (exploreAccessibilityEventName.compareTo(eventText) == 0) {
                 MainActivity.reset(getApplicationContext());
             }
         }

--- a/Launcher/App/src/main/java/com/lvonasek/pilauncher/MainActivity.java
+++ b/Launcher/App/src/main/java/com/lvonasek/pilauncher/MainActivity.java
@@ -247,6 +247,7 @@ public class MainActivity extends Activity
         boolean editMode = !mPreferences.getBoolean(SettingsProvider.KEY_EDITMODE, false);
         apps.setIcon(editMode ? R.drawable.ic_editing_on : R.drawable.ic_editing_off);
         apps.setText(getString(editMode ? R.string.settings_apps_enable : R.string.settings_apps_disable));
+        apps.setTooltipText(getString(editMode ? R.string.settings_apps_enable : R.string.settings_apps_disable));
         apps.setOnClickListener(view1 -> {
             ArrayList<String> selected = mSettings.getAppGroupsSorted(true);
             if (editMode && (selected.size() > 1)) {

--- a/Launcher/App/src/main/java/com/lvonasek/pilauncher/SettingsProvider.java
+++ b/Launcher/App/src/main/java/com/lvonasek/pilauncher/SettingsProvider.java
@@ -29,6 +29,7 @@ public class SettingsProvider
     private final String SEPARATOR = "#@%";
 
     private static SettingsProvider instance;
+    private static Context context;
 
     public static synchronized SettingsProvider getInstance (Context context)
     {
@@ -46,6 +47,7 @@ public class SettingsProvider
 
     private SettingsProvider(Context context) {
         mPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        this.context = context;
     }
 
     public void setAppList(Map<String, String> appList)
@@ -164,7 +166,7 @@ public class SettingsProvider
         try
         {
             Set<String> def = new HashSet<>();
-            def.add("Apps");
+            def.add(context.getString(R.string.default_apps_group));
             mAppGroups = mPreferences.getStringSet(KEY_APP_GROUPS, def);
             mSelectedGroups = mPreferences.getStringSet(KEY_SELECTED_GROUPS, def);
 

--- a/Launcher/App/src/main/res/layout/dialog_settings.xml
+++ b/Launcher/App/src/main/res/layout/dialog_settings.xml
@@ -24,6 +24,7 @@
             android:id="@+id/settings_look"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/settings_look"
             app:icon="@drawable/ic_look"
             app:text="@string/settings_look"/>
 
@@ -31,6 +32,7 @@
             android:id="@+id/settings_device"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/settings_device"
             app:icon="@drawable/ic_device"
             app:text="@string/settings_device"/>
 
@@ -38,6 +40,7 @@
             android:id="@+id/settings_apps"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/settings_apps_enable"
             app:icon="@drawable/ic_editing_on"
             app:text="@string/settings_apps_enable"/>
 
@@ -45,6 +48,7 @@
             android:id="@+id/settings_tweaks"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/settings_tweaks"
             app:icon="@drawable/ic_tweaks"
             app:text="@string/settings_tweaks"/>
     </LinearLayout>

--- a/Launcher/App/src/main/res/layout/dialog_tweaks.xml
+++ b/Launcher/App/src/main/res/layout/dialog_tweaks.xml
@@ -25,6 +25,7 @@
             android:id="@+id/service_app_shortcut"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/service_app_shortcut"
             app:icon="@drawable/ic_shortcut"
             app:text="@string/service_app_shortcut"/>
 
@@ -32,6 +33,7 @@
             android:id="@+id/service_explore_app"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/service_explore_app"
             app:icon="@drawable/ic_explore"
             app:text="@string/service_explore_app"/>
 
@@ -39,6 +41,7 @@
             android:id="@+id/service_multiwindow"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/service_multiwindow"
             app:icon="@drawable/ic_multiwindow"
             app:text="@string/service_multiwindow"/>
 
@@ -46,6 +49,7 @@
             android:id="@+id/service_os_updater"
             android:layout_width="120dp"
             android:layout_height="120dp"
+            android:tooltipText="@string/service_os_updater"
             app:icon="@drawable/ic_updater"
             app:text="@string/service_os_updater"/>
     </LinearLayout>

--- a/Launcher/App/src/main/res/values-da/strings.xml
+++ b/Launcher/App/src/main/res/values-da/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Udforsk]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-de/strings.xml
+++ b/Launcher/App/src/main/res/values-de/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Entdecken]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-es/strings.xml
+++ b/Launcher/App/src/main/res/values-es/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Explorar]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-fr/strings.xml
+++ b/Launcher/App/src/main/res/values-fr/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="explore_accessibility_event_name">[Explore]</string>
+    <string name="explore_accessibility_event_name">[Explorer]</string>
 </resources>

--- a/Launcher/App/src/main/res/values-fr/strings.xml
+++ b/Launcher/App/src/main/res/values-fr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Explore]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-it/strings.xml
+++ b/Launcher/App/src/main/res/values-it/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Esplora]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-nl/strings.xml
+++ b/Launcher/App/src/main/res/values-nl/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Ontdekken]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-pl/strings.xml
+++ b/Launcher/App/src/main/res/values-pl/strings.xml
@@ -1,0 +1,30 @@
+<resources>
+    <string name="app_name">.. \u03C0 Launcher ..</string>
+    <string name="default_apps_group">Aplikacje</string>
+    <string name="add_group">Dodaj grupę</string>
+    <string name="delete_group">Usuń grupę</string>
+    <string name="edit_group">Edytuj grupę</string>
+    <string name="app_details">Szczegóły aplikacji</string>
+    <string name="apps_hidden">Ukryte</string>
+
+    <string name="settings_apps_enable">Wł. edytowanie</string>
+    <string name="settings_apps_disable">Wył. edytowanie</string>
+    <string name="settings_device">Ustawienia urządzenia</string>
+    <string name="settings_look">Dostosuj</string>
+    <string name="settings_tweaks">Usprawnienia systemowe</string>
+    <string name="background_opacity">Przezroczystość tła</string>
+    <string name="icons_size">Rozmiar ikon</string>
+    <string name="show_app_names">Pokaż nazwy aplikacji</string>
+    <string name="start_shortcut">Otwórz launcher za pomocą ikony Eksploruj z poziomu paska systemowego. W celu lepszego działania zaleca się wyłączenie aplikacji Eksploruj.</string>
+
+    <string name="service_app_shortcut">Skrót aplikacji</string>
+    <string name="service_explore_app">Aplikacja Eksploruj</string>
+    <string name="service_multiwindow">Tryb wielu okien</string>
+    <string name="service_os_updater">Aktualizator systemu</string>
+
+    <string name="service_enable">Włącz</string>
+    <string name="service_disable">Wyłącz</string>
+    <string name="service_multiwindow_desc">Aplikacje 2D są zawsze otwierane na środkowej pozycji w trybie wielu okien. Włączenie trybu wielu okien spowoduje, że aplikacje będą otwierane w nowym oknie. Czy chcesz włączyć lub wyłączyć tę funkcję?</string>
+
+    <string name="explore_accessibility_event_name">[Eksploruj]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-ru/strings.xml
+++ b/Launcher/App/src/main/res/values-ru/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Лента]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-sv/strings.xml
+++ b/Launcher/App/src/main/res/values-sv/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="explore_accessibility_event_name">[Utforska]</string>
+</resources>

--- a/Launcher/App/src/main/res/values/strings.xml
+++ b/Launcher/App/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">.. \u03C0 Launcher ..</string>
+    <string name="default_apps_group">Apps</string>
     <string name="add_group">Add group</string>
     <string name="delete_group">Delete group</string>
     <string name="edit_group">Edit group</string>
@@ -14,7 +15,7 @@
     <string name="background_opacity">Background opacity</string>
     <string name="icons_size">Icons size</string>
     <string name="show_app_names">Show app names</string>
-    <string name="start_shortcut">Open the launcher with Explore icon from the system dashboard. For a smooth experience it is recommended to disable the Explore app.\n\nTHIS WILL NOT WORK IF THE HEADSET LANGUAGE IS NOT SET TO ENGLISH.</string>
+    <string name="start_shortcut">Open the launcher with Explore icon from the system dashboard. For a smooth experience it is recommended to disable the Explore app.\n\nDOES NOT SUPPORT ALL HEADSET LANGUAGES. SET YOUR HEADSET LANGUAGE TO ENGLISH IF THIS FEATURE DOES NOT WORK PROPERLY.</string>
 
     <string name="service_app_shortcut">App shortcut</string>
     <string name="service_explore_app">Explore app</string>
@@ -24,4 +25,6 @@
     <string name="service_enable">Enable</string>
     <string name="service_disable">Disable</string>
     <string name="service_multiwindow_desc">2D apps are always opened in the middle multiwindow slot. By enabling multiwindow in the launcher the opened apps will be opened in a new window. Do you want to enable or disable this feature?</string>
+
+    <string name="explore_accessibility_event_name">[Explore]</string>
 </resources>


### PR DESCRIPTION
* In total 10 languages now support the shortcut: English, Danish, German, Spanish, French, Italian, Dutch, Polish, Russian, Swedish
* Translated the app into Polish

Inspired by PR #1 I decided to give it a shot and add more languages that will work with the Explore shortcut. Initially I wanted to do it in a dirty way by storing strings for all languages in a string array within the main strings file but ultimately I decided to just use the native Android localization. While I was at it I went ahead and translated all of the strings into Polish, since I'm Polish myself! If you think supporting different translations isn't something to have in the app, feel free to scrap it. 

Polish strings turned out to be quite long and got truncated in the layout so as a workaround I added tooltips that will display the full name on hover.

Name of the default apps group was also localized which required passing a context to a non-activity class so the name can be pulled from string resources.